### PR TITLE
Fix cursor position for multibyte

### DIFF
--- a/rl.go
+++ b/rl.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"os"
 	"os/signal"
+	"unicode/utf8"
 )
 
 type Rl struct {
@@ -111,7 +112,7 @@ loop:
 						tmp = append(tmp, []rune(item)...)
 						c.input = tmp
 						dirty = true
-						c.cursor_x = r.completePos + common
+						c.cursor_x = r.completePos + utf8.RuneCountInString(item)
 					}
 				}
 			case 10: // LF


### PR DESCRIPTION
Hello! Thank you for your nice library!!

I fixed the cursor position on when using multibyte.
I found to cause a panic if completion uses for multibyte text.

thank you.

mattnさんこんにちは。
今、標準入力でパス補完をするような機能を作るのにこのライブラリを使わせていただいています。
日本語ディレクトリの補完時にpanicが発生することがわかったので、修正してみました。
お時間ある時にご確認していただければ嬉しいです^ - ^