### PR TITLE
Fix Windows CI build

### DIFF
--- a/rl_test.go
+++ b/rl_test.go
@@ -72,21 +72,3 @@ func TestDeleteWordBeforeCursor(t *testing.T) {
 		t.Fatalf("deleteWordBeforeCursor cursor = %d, want 4", cursor)
 	}
 }
-
-func TestDecodeRunesKeepsIncompleteUTF8(t *testing.T) {
-	rs, pending := decodeRunes([]byte{0xe3, 0x81})
-	if len(rs) != 0 {
-		t.Fatalf("decodeRunes returned runes %q, want none", string(rs))
-	}
-	if len(pending) != 2 {
-		t.Fatalf("decodeRunes pending length = %d, want 2", len(pending))
-	}
-
-	rs, pending = decodeRunes(append(pending, 0x82))
-	if string(rs) != "あ" {
-		t.Fatalf("decodeRunes = %q, want %q", string(rs), "あ")
-	}
-	if len(pending) != 0 {
-		t.Fatalf("decodeRunes pending length = %d, want 0", len(pending))
-	}
-}

--- a/rl_unix_test.go
+++ b/rl_unix_test.go
@@ -1,0 +1,24 @@
+//go:build !windows
+// +build !windows
+
+package rl
+
+import "testing"
+
+func TestDecodeRunesKeepsIncompleteUTF8(t *testing.T) {
+	rs, pending := decodeRunes([]byte{0xe3, 0x81})
+	if len(rs) != 0 {
+		t.Fatalf("decodeRunes returned runes %q, want none", string(rs))
+	}
+	if len(pending) != 2 {
+		t.Fatalf("decodeRunes pending length = %d, want 2", len(pending))
+	}
+
+	rs, pending = decodeRunes(append(pending, 0x82))
+	if string(rs) != "あ" {
+		t.Fatalf("decodeRunes = %q, want %q", string(rs), "あ")
+	}
+	if len(pending) != 0 {
+		t.Fatalf("decodeRunes pending length = %d, want 0", len(pending))
+	}
+}


### PR DESCRIPTION
rl_test.go referenced `decodeRunes` (defined only in the `!windows` build), so the test package failed to compile on Windows once CI started running there. Move that test into a new `//go:build !windows` file `rl_unix_test.go`; the remaining cross-platform tests now build on Windows too.